### PR TITLE
Change primaryKey on date field from a string to a boolean

### DIFF
--- a/datapackage.json
+++ b/datapackage.json
@@ -395,7 +395,7 @@
     "date": {
       "fields": {
         "year": {
-          "primaryKey": "",
+          "primaryKey": true,
           "source": "year"
         }
       }


### PR DESCRIPTION
It's not obvious from the spec but given the example in the section
about dimensions: http://fiscal.dataprotocols.org/spec/#dimensions
the ``primaryKey`` should be a boolean, not a string.