### PR TITLE
Change location property key to countryCode

### DIFF
--- a/datapackage.json
+++ b/datapackage.json
@@ -7,7 +7,7 @@
   "granularity": "aggregated",
   "direction": "expenditure",
   "status": "executed",
-  "location": "AM",
+  "countryCode": "AM",
   "profiles": {
     "openspending": "*",
     "tabular": "*"


### PR DESCRIPTION
The newest version of budget data package uses the property key
'countryCode' instead of 'location' (as the old versions did).